### PR TITLE
Array of $emotions can have missing indexes.

### DIFF
--- a/MNAddEmotionAttributes.php
+++ b/MNAddEmotionAttributes.php
@@ -1,6 +1,5 @@
 <?php
 namespace MNAddEmotionAttributes;
-use Noodlehaus\Exception;
 use Shopware\Components\Plugin\Context\ActivateContext;
 use Shopware\Components\Plugin\Context\DeactivateContext;
 use Shopware\Components\Plugin\Context\InstallContext;

--- a/MNAddEmotionAttributes.php
+++ b/MNAddEmotionAttributes.php
@@ -1,5 +1,6 @@
 <?php
 namespace MNAddEmotionAttributes;
+use Noodlehaus\Exception;
 use Shopware\Components\Plugin\Context\ActivateContext;
 use Shopware\Components\Plugin\Context\DeactivateContext;
 use Shopware\Components\Plugin\Context\InstallContext;
@@ -70,12 +71,10 @@ class MNAddEmotionAttributes extends \Shopware\Components\Plugin
 
         $service = $this->container->get('shopware_attribute.data_loader');
 
-        $i = 0;
-        foreach ($emotions as $emotion)
+        foreach ($emotions as $key => $emotion)
         {
             $attributes['attributes'] = $service->load('s_emotion_attributes', $emotion['id']);
-            $emotions[$i] = $emotions[$i] + $attributes;
-            $i++;
+            $emotions[$key] = array_merge($emotion,  $attributes);
         }
 
         $view->assign('emotions', $emotions);


### PR DESCRIPTION
This causes a fatal error in the assignment with $i.
I suppose when shopping worlds get removed from $emotions the array is not re-indexed.
Maybe this happens when shopping worlds get deactivated. I did not investigate this more deeply, just fixed the code.